### PR TITLE
fix(sdk): sort multi-valued target/enrichment attributes on serve

### DIFF
--- a/docs/discovery-api.md
+++ b/docs/discovery-api.md
@@ -184,6 +184,7 @@ You can provide a list of attribute definitions. The platform will use these att
 ### References
 
 - [Go API](https://github.com/steadybit/discovery-kit/tree/main/go/discovery_kit_api): `AttributeDescriptions`
+- [OpenAPI Schema](https://github.com/steadybit/discovery-kit/tree/main/openapi): `AttributeDescriptions`
 
 ## Multi-valued Attribute Values
 
@@ -195,25 +196,22 @@ A discovery that publishes two or more multi-valued attributes whose *positions*
 
 ```json
 {
-  "k8s.hpa.name":         ["hpa-b", "hpa-a"],
-  "k8s.hpa.min-replicas": ["3",     "1"]
+  "k8s.hpa.name":         ["aaa", "bbb"],
+  "k8s.hpa.min-replicas": ["10",  "1"]
 }
 ```
 
-…where the intent is `hpa-b → 3` and `hpa-a → 1`, the SDK sorts each slice independently and the resulting payload reads as `hpa-a → 3, hpa-b → 1` — wrong data, no warning.
+…where the intent is `aaa → 10` and `bbb → 1`, the SDK sorts each slice independently. The `name` array is already sorted so it stays put; the `min-replicas` array becomes `["1", "10"]`. The resulting payload reads as `aaa → 1, bbb → 10` — wrong data, no warning.
 
 **Recommended pattern**: encode paired values into one self-contained string per entry, so each list element is a set member and the sort cannot break the pairing:
 
 ```json
 {
-  "k8s.hpa": ["hpa-a:min=1,max=5", "hpa-b:min=3,max=10"]
+  "k8s.hpa": ["aaa:min=10,max=20", "bbb:min=1,max=5"]
 }
 ```
 
-**Compatibility pattern (if you can't change the wire shape)**: pre-sort the source data by the *primary* attribute before building every parallel slice. As long as every parallel attribute follows the primary's sort order, the SDK's per-attribute sort is a stable no-op. See `extension-kubernetes/extcommon/hpa_pdb_rollup.go` for an example: it sorts the input HPA/PDB slice once at the top of the function and then iterates that sorted source to build all parallel attribute slices.
-
-
-- [OpenAPI Schema](https://github.com/steadybit/discovery-kit/tree/main/openapi): `AttributeDescriptions`
+**Compatibility pattern (if you can't change the wire shape)**: pre-sort the source data by the *primary* attribute before building every parallel slice. As long as every parallel attribute follows the primary's sort order, the SDK's per-attribute sort is a stable no-op. This pattern is fragile — any future contributor who builds a parallel slice from a different iteration order silently corrupts the data — so prefer the self-contained-string encoding unless you cannot change the wire shape. See `extension-kubernetes/extcommon/hpa_pdb_rollup.go` for a working example: it sorts the input HPA/PDB slice once at the top of the function and then iterates that sorted source to build all parallel attribute slices.
 
 ## Target Enrichment Rules
 

--- a/docs/discovery-api.md
+++ b/docs/discovery-api.md
@@ -184,6 +184,35 @@ You can provide a list of attribute definitions. The platform will use these att
 ### References
 
 - [Go API](https://github.com/steadybit/discovery-kit/tree/main/go/discovery_kit_api): `AttributeDescriptions`
+
+## Multi-valued Attribute Values
+
+Each target attribute value is a JSON array of strings (`map[string][]string` in Go). The platform and the Go SDK both treat the **values within a single attribute as a set, not as an ordered list**: their order carries no semantic meaning. The Go SDK sorts every multi-valued slice before serving so that map-iteration noise from the source data (e.g. Go maps, Kubernetes client-go listers — both randomize) does not look like a change to the platform's target-diff detector. Without that normalization a discovery on unchanged data would re-upload every multi-X target on every cycle, hammering the platform's target store.
+
+### Pitfall: parallel multi-valued attributes
+
+A discovery that publishes two or more multi-valued attributes whose *positions* are meant to pair across attributes will be silently broken by per-attribute sorting. For example, given:
+
+```json
+{
+  "k8s.hpa.name":         ["hpa-b", "hpa-a"],
+  "k8s.hpa.min-replicas": ["3",     "1"]
+}
+```
+
+…where the intent is `hpa-b → 3` and `hpa-a → 1`, the SDK sorts each slice independently and the resulting payload reads as `hpa-a → 3, hpa-b → 1` — wrong data, no warning.
+
+**Recommended pattern**: encode paired values into one self-contained string per entry, so each list element is a set member and the sort cannot break the pairing:
+
+```json
+{
+  "k8s.hpa": ["hpa-a:min=1,max=5", "hpa-b:min=3,max=10"]
+}
+```
+
+**Compatibility pattern (if you can't change the wire shape)**: pre-sort the source data by the *primary* attribute before building every parallel slice. As long as every parallel attribute follows the primary's sort order, the SDK's per-attribute sort is a stable no-op. See `extension-kubernetes/extcommon/hpa_pdb_rollup.go` for an example: it sorts the input HPA/PDB slice once at the top of the function and then iterates that sorted source to build all parallel attribute slices.
+
+
 - [OpenAPI Schema](https://github.com/steadybit/discovery-kit/tree/main/openapi): `AttributeDescriptions`
 
 ## Target Enrichment Rules

--- a/go/discovery_kit_sdk/discovery_http_adapter.go
+++ b/go/discovery_kit_sdk/discovery_http_adapter.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 
 	"github.com/rs/zerolog/log"
@@ -83,9 +84,7 @@ func (a discoveryHttpAdapter) handleDiscover(w http.ResponseWriter, r *http.Requ
 		if err != nil {
 			allErrs = errors.Join(allErrs, err)
 		}
-		if group != "" {
-			targets = withGroupAttribute(targets, group)
-		}
+		targets = normalizeTargets(targets, group)
 		body.Targets = extutil.Ptr(targets)
 	}
 	if e, ok := a.discovery.(EnrichmentDataDiscovery); ok {
@@ -94,9 +93,7 @@ func (a discoveryHttpAdapter) handleDiscover(w http.ResponseWriter, r *http.Requ
 		if err != nil {
 			allErrs = errors.Join(allErrs, err)
 		}
-		if group != "" {
-			data = withGroupAttributeEnrichment(data, group)
-		}
+		data = normalizeEnrichmentData(data, group)
 		body.EnrichmentData = extutil.Ptr(data)
 	}
 	if allErrs != nil {
@@ -106,35 +103,60 @@ func (a discoveryHttpAdapter) handleDiscover(w http.ResponseWriter, r *http.Requ
 	exthttp.WriteBody(w, body)
 }
 
-// withGroupAttribute returns a new slice of targets where each target's Attributes map is a
-// fresh copy with the group attribute set. The discovery's underlying maps are never mutated,
-// which keeps concurrent calls to handleDiscover safe — without this, two requests could
-// write to the same cached map while a third was iterating it for JSON encoding, causing a
-// "concurrent map iteration and map write" panic.
-func withGroupAttribute(targets []discovery_kit_api.Target, group string) []discovery_kit_api.Target {
+// normalizeTargets returns a defensive copy of the target list where each Attributes map is a
+// fresh copy with multi-valued slices sorted, and (optionally) the steadybit.group attribute set.
+//
+// The discovery's underlying maps are never mutated, which keeps concurrent calls to handleDiscover
+// safe — without the copy, two requests could write to the same cached map while a third was
+// iterating it for JSON encoding, causing a "concurrent map iteration and map write" panic.
+//
+// The sort is the load-bearing part: the platform's target-diff detector compares multi-valued
+// attribute slices by position, so extensions that build them from a Go map or a Kubernetes
+// client-go lister (both of which iterate in randomized order) would otherwise make every such
+// target look "changed" on every discovery cycle, driving needless writes to the platform's
+// target store. Sorting at the SDK level keeps every Go-based extension safe by default.
+//
+// Note for extensions: multi-valued attributes are normalized as **sets**. If you use parallel
+// multi-valued attributes (where the i-th element of one pairs with the i-th of another), pre-sort
+// your source so the per-attribute sort here keeps the pairing aligned, or encode paired values
+// into a single self-contained string per entry.
+func normalizeTargets(targets []discovery_kit_api.Target, group string) []discovery_kit_api.Target {
 	out := make([]discovery_kit_api.Target, len(targets))
 	for i, t := range targets {
 		out[i] = t
-		out[i].Attributes = copyAttributesWithGroup(t.Attributes, group)
+		out[i].Attributes = normalizeAttributes(t.Attributes, group)
 	}
 	return out
 }
 
-func withGroupAttributeEnrichment(data []discovery_kit_api.EnrichmentData, group string) []discovery_kit_api.EnrichmentData {
+func normalizeEnrichmentData(data []discovery_kit_api.EnrichmentData, group string) []discovery_kit_api.EnrichmentData {
 	out := make([]discovery_kit_api.EnrichmentData, len(data))
 	for i, d := range data {
 		out[i] = d
-		out[i].Attributes = copyAttributesWithGroup(d.Attributes, group)
+		out[i].Attributes = normalizeAttributes(d.Attributes, group)
 	}
 	return out
 }
 
-func copyAttributesWithGroup(src map[string][]string, group string) map[string][]string {
-	dst := make(map[string][]string, len(src)+1)
-	for k, v := range src {
-		dst[k] = v
+func normalizeAttributes(src map[string][]string, group string) map[string][]string {
+	extra := 0
+	if group != "" {
+		extra = 1
 	}
-	dst[groupAttributeKey] = []string{group}
+	dst := make(map[string][]string, len(src)+extra)
+	for k, v := range src {
+		if len(v) > 1 {
+			sorted := make([]string, len(v))
+			copy(sorted, v)
+			sort.Strings(sorted)
+			dst[k] = sorted
+		} else {
+			dst[k] = v
+		}
+	}
+	if group != "" {
+		dst[groupAttributeKey] = []string{group}
+	}
 	return dst
 }
 

--- a/go/discovery_kit_sdk/discovery_http_adapter.go
+++ b/go/discovery_kit_sdk/discovery_http_adapter.go
@@ -121,6 +121,9 @@ func (a discoveryHttpAdapter) handleDiscover(w http.ResponseWriter, r *http.Requ
 // your source so the per-attribute sort here keeps the pairing aligned, or encode paired values
 // into a single self-contained string per entry.
 func normalizeTargets(targets []discovery_kit_api.Target, group string) []discovery_kit_api.Target {
+	if !targetsNeedNormalize(targets, group) {
+		return targets
+	}
 	out := make([]discovery_kit_api.Target, len(targets))
 	for i, t := range targets {
 		out[i] = t
@@ -130,12 +133,53 @@ func normalizeTargets(targets []discovery_kit_api.Target, group string) []discov
 }
 
 func normalizeEnrichmentData(data []discovery_kit_api.EnrichmentData, group string) []discovery_kit_api.EnrichmentData {
+	if !enrichmentNeedsNormalize(data, group) {
+		return data
+	}
 	out := make([]discovery_kit_api.EnrichmentData, len(data))
 	for i, d := range data {
 		out[i] = d
 		out[i].Attributes = normalizeAttributes(d.Attributes, group)
 	}
 	return out
+}
+
+// targetsNeedNormalize / enrichmentNeedsNormalize keep the no-copy fast path
+// for discoveries with no group configured and whose multi-valued attribute
+// slices already come out sorted. Without this, every serve allocates a fresh
+// map per target whether or not anything would change — measurable cost on
+// large-fan-out discoveries (10k+ targets) polled at tight intervals.
+func targetsNeedNormalize(targets []discovery_kit_api.Target, group string) bool {
+	if group != "" {
+		return true
+	}
+	for _, t := range targets {
+		if attributesNeedNormalize(t.Attributes) {
+			return true
+		}
+	}
+	return false
+}
+
+func enrichmentNeedsNormalize(data []discovery_kit_api.EnrichmentData, group string) bool {
+	if group != "" {
+		return true
+	}
+	for _, d := range data {
+		if attributesNeedNormalize(d.Attributes) {
+			return true
+		}
+	}
+	return false
+}
+
+func attributesNeedNormalize(src map[string][]string) bool {
+	for _, v := range src {
+		if len(v) > 1 && !sort.StringsAreSorted(v) {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeAttributes(src map[string][]string, group string) map[string][]string {
@@ -145,7 +189,7 @@ func normalizeAttributes(src map[string][]string, group string) map[string][]str
 	}
 	dst := make(map[string][]string, len(src)+extra)
 	for k, v := range src {
-		if len(v) > 1 {
+		if len(v) > 1 && !sort.StringsAreSorted(v) {
 			sorted := make([]string, len(v))
 			copy(sorted, v)
 			sort.Strings(sorted)

--- a/go/discovery_kit_sdk/discovery_http_adapter.go
+++ b/go/discovery_kit_sdk/discovery_http_adapter.go
@@ -103,12 +103,17 @@ func (a discoveryHttpAdapter) handleDiscover(w http.ResponseWriter, r *http.Requ
 	exthttp.WriteBody(w, body)
 }
 
-// normalizeTargets returns a defensive copy of the target list where each Attributes map is a
-// fresh copy with multi-valued slices sorted, and (optionally) the steadybit.group attribute set.
+// normalizeTargets ensures every multi-valued attribute slice in the response is sorted, and
+// optionally injects the steadybit.group attribute on every target. It has two branches:
 //
-// The discovery's underlying maps are never mutated, which keeps concurrent calls to handleDiscover
-// safe — without the copy, two requests could write to the same cached map while a third was
-// iterating it for JSON encoding, causing a "concurrent map iteration and map write" panic.
+//   - Fast path (group == "" AND every multi-valued slice is already sorted): the input slice is
+//     returned verbatim, no allocation. The discovery's underlying maps are caller-visible through
+//     the return value, so callers MUST NOT mutate them. This keeps the no-work-needed case free
+//     of GC pressure on large-fan-out discoveries.
+//   - Slow path (group set OR any multi-valued slice unsorted): returns a fresh slice where each
+//     Attributes map is a fresh copy with multi-valued slices sorted into a new backing array.
+//     The source maps are never mutated, so concurrent calls to handleDiscover stay safe under
+//     JSON encoding even though the discovery cache may rebuild its internal maps in-flight.
 //
 // The sort is the load-bearing part: the platform's target-diff detector compares multi-valued
 // attribute slices by position, so extensions that build them from a Go map or a Kubernetes
@@ -119,7 +124,8 @@ func (a discoveryHttpAdapter) handleDiscover(w http.ResponseWriter, r *http.Requ
 // Note for extensions: multi-valued attributes are normalized as **sets**. If you use parallel
 // multi-valued attributes (where the i-th element of one pairs with the i-th of another), pre-sort
 // your source so the per-attribute sort here keeps the pairing aligned, or encode paired values
-// into a single self-contained string per entry.
+// into a single self-contained string per entry. See docs/discovery-api.md, section
+// "Multi-valued Attribute Values".
 func normalizeTargets(targets []discovery_kit_api.Target, group string) []discovery_kit_api.Target {
 	if !targetsNeedNormalize(targets, group) {
 		return targets

--- a/go/discovery_kit_sdk/discovery_http_adapter_group_test.go
+++ b/go/discovery_kit_sdk/discovery_http_adapter_group_test.go
@@ -14,7 +14,7 @@ func Test_withGroupAttribute_copies_map(t *testing.T) {
 	src := map[string][]string{"k": {"v"}}
 	targets := []discovery_kit_api.Target{{Id: "a", Attributes: src}}
 
-	out := withGroupAttribute(targets, "prod-eu")
+	out := normalizeTargets(targets, "prod-eu")
 
 	assert.Equal(t, []string{"prod-eu"}, out[0].Attributes[groupAttributeKey])
 	assert.Equal(t, []string{"v"}, out[0].Attributes["k"])
@@ -25,11 +25,11 @@ func Test_withGroupAttribute_copies_map(t *testing.T) {
 	assert.NotSame(t, &targets[0].Attributes, &out[0].Attributes)
 }
 
-func Test_withGroupAttributeEnrichment_copies_map(t *testing.T) {
+func Test_normalizeEnrichmentData_copies_map(t *testing.T) {
 	src := map[string][]string{"k": {"v"}}
 	data := []discovery_kit_api.EnrichmentData{{Id: "a", Attributes: src}}
 
-	out := withGroupAttributeEnrichment(data, "prod-eu")
+	out := normalizeEnrichmentData(data, "prod-eu")
 
 	assert.Equal(t, []string{"prod-eu"}, out[0].Attributes[groupAttributeKey])
 	_, present := src[groupAttributeKey]
@@ -52,7 +52,7 @@ func Test_withGroupAttribute_is_concurrent_safe(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 500; j++ {
-				out := withGroupAttribute(shared, "prod-eu")
+				out := normalizeTargets(shared, "prod-eu")
 				for _, tg := range out {
 					for k, v := range tg.Attributes {
 						_ = k
@@ -72,7 +72,26 @@ func Test_withGroupAttribute_is_concurrent_safe(t *testing.T) {
 	wg.Wait()
 }
 
-func Test_copyAttributesWithGroup_handles_nil_source(t *testing.T) {
-	out := copyAttributesWithGroup(nil, "g")
+func Test_normalizeAttributes_handles_nil_source(t *testing.T) {
+	out := normalizeAttributes(nil, "g")
 	assert.Equal(t, []string{"g"}, out[groupAttributeKey])
+}
+
+// Test_normalizeAttributes_sorts_multivalued locks in the fix for the
+// extension-kubernetes platform-DB churn incident: multi-valued attribute slices
+// must come out in a stable order even when the source is in random Go-map order,
+// otherwise the platform's target-diff sees a change every cycle and re-writes.
+func Test_normalizeAttributes_sorts_multivalued(t *testing.T) {
+	src := map[string][]string{
+		"single":  {"only"},
+		"k8s.hpa": {"bbb", "aaa", "ccc"},
+		"k8s.pdb": {"zzz", "aaa"},
+	}
+	out := normalizeAttributes(src, "")
+
+	assert.Equal(t, []string{"only"}, out["single"], "single-valued slice untouched")
+	assert.Equal(t, []string{"aaa", "bbb", "ccc"}, out["k8s.hpa"], "multi-valued slice sorted")
+	assert.Equal(t, []string{"aaa", "zzz"}, out["k8s.pdb"], "multi-valued slice sorted")
+	// Source must not be mutated.
+	assert.Equal(t, []string{"bbb", "aaa", "ccc"}, src["k8s.hpa"], "source slice must not be mutated")
 }

--- a/go/discovery_kit_sdk/discovery_http_adapter_group_test.go
+++ b/go/discovery_kit_sdk/discovery_http_adapter_group_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/steadybit/discovery-kit/go/discovery_kit_api"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_normalizeTargets_copies_map_when_group_set(t *testing.T) {
@@ -105,6 +106,11 @@ func Test_normalizeAttributes_sorts_multivalued(t *testing.T) {
 	assert.Equal(t, []string{"only"}, out["single"], "single-valued slice untouched")
 	assert.Equal(t, []string{"aaa", "bbb", "ccc"}, out["k8s.hpa"], "multi-valued slice sorted")
 	assert.Equal(t, []string{"aaa", "zzz"}, out["k8s.pdb"], "multi-valued slice sorted")
+	// group=="" must NOT inject a steadybit.group attribute — without this assertion a regression
+	// that drops the `if group != ""` guard would silently ship phantom `steadybit.group: [""]`
+	// attributes on every target.
+	_, hasGroup := out[groupAttributeKey]
+	assert.False(t, hasGroup, "group key must be absent when group is empty")
 	// Both source slices must be untouched (catches an in-place-sort regression
 	// even when one attribute happens to be 2 elements — the case most likely
 	// to be "optimised" into a swap-in-place).
@@ -133,20 +139,63 @@ func Test_normalizeAttributes_sorts_multivalued_with_group(t *testing.T) {
 // targets whose multi-valued attributes are already sorted and that have no
 // group configured are returned without a fresh allocation. Avoids a
 // per-cycle map-copy regression on large-fan-out discoveries.
+//
+// The test asserts the *backing array is shared* (slice header identity), not
+// caller-visible mutation through the boundary. A future maintainer who
+// legitimately reintroduces a defensive copy (e.g. to harden against a new
+// mutate-after-return contract) should be able to revisit this test by
+// changing the assertion — not be tempted to revert their copy.
 func Test_normalizeTargets_fast_path_no_copy_when_already_sorted(t *testing.T) {
-	original := map[string][]string{
-		"single":  {"only"},
-		"k8s.hpa": {"aaa", "bbb", "ccc"}, // already sorted
+	targets := []discovery_kit_api.Target{
+		{Id: "a", Attributes: map[string][]string{"single": {"only"}, "k8s.hpa": {"aaa", "bbb", "ccc"}}},
+		{Id: "b", Attributes: map[string][]string{"k8s.pdb": {"aaa", "zzz"}}},
 	}
-	targets := []discovery_kit_api.Target{{Id: "a", Attributes: original}}
 
 	out := normalizeTargets(targets, "")
 
-	// Same backing slice — no copy was made.
-	assert.Same(t, &targets[0], &out[0], "fast path should return the original slice")
-	// And the map header itself must alias the source, so a write to the returned
-	// map is visible in the source (this is the no-copy contract).
-	out[0].Attributes["touch"] = []string{"x"}
-	_, present := original["touch"]
-	assert.True(t, present, "fast path returns the original map; write is visible in source")
+	// Slice-header identity: same backing array, same len/cap. Not just element-0 aliasing —
+	// a regression like `return targets[:1:1]` would satisfy &targets[0]==&out[0] but break
+	// callers who rely on the full input being returned.
+	require.Equal(t, len(targets), len(out), "fast path must return all targets")
+	assert.Same(t, &targets[0], &out[0], "fast path must share the underlying array")
+	assert.Same(t, &targets[1], &out[1], "every element must alias, not just the first")
+}
+
+// Test_normalizeEnrichmentData_fast_path_no_copy_when_already_sorted mirrors
+// the targets fast-path test for enrichment data — without it, a future
+// regression that inverts enrichmentNeedsNormalize would silently re-introduce
+// per-cycle map allocations for enrichment-data discoveries.
+func Test_normalizeEnrichmentData_fast_path_no_copy_when_already_sorted(t *testing.T) {
+	data := []discovery_kit_api.EnrichmentData{
+		{Id: "a", Attributes: map[string][]string{"single": {"only"}, "k8s.hpa": {"aaa", "bbb"}}},
+		{Id: "b", Attributes: map[string][]string{"k8s.pdb": {"aaa", "zzz"}}},
+	}
+
+	out := normalizeEnrichmentData(data, "")
+
+	require.Equal(t, len(data), len(out))
+	assert.Same(t, &data[0], &out[0], "fast path must share the underlying array")
+	assert.Same(t, &data[1], &out[1])
+}
+
+// Test_normalizeTargets_slow_path_allocates_when_unsorted covers the wiring
+// from normalizeTargets through to normalizeAttributes: with no group and an
+// unsorted multi-valued attribute on at least one target, the SDK MUST
+// allocate a fresh map for that target with the slice sorted on the wire,
+// and the source slice must remain untouched.
+func Test_normalizeTargets_slow_path_allocates_when_unsorted(t *testing.T) {
+	srcAttrs := map[string][]string{"k8s.hpa": {"bbb", "aaa"}} // unsorted
+	targets := []discovery_kit_api.Target{{Id: "a", Attributes: srcAttrs}}
+
+	out := normalizeTargets(targets, "")
+
+	// Wire output must be sorted — this is the SDK's primary contract.
+	assert.Equal(t, []string{"aaa", "bbb"}, out[0].Attributes["k8s.hpa"], "wire output sorted")
+	// Source slice must be untouched.
+	assert.Equal(t, []string{"bbb", "aaa"}, srcAttrs["k8s.hpa"], "source slice not mutated")
+	// Mutating the returned Attributes map must NOT leak into the source — proves the slow path
+	// produced a fresh map.
+	out[0].Attributes["sentinel"] = []string{"x"}
+	_, leaked := srcAttrs["sentinel"]
+	assert.False(t, leaked, "slow path must return a fresh Attributes map")
 }

--- a/go/discovery_kit_sdk/discovery_http_adapter_group_test.go
+++ b/go/discovery_kit_sdk/discovery_http_adapter_group_test.go
@@ -4,13 +4,14 @@
 package discovery_kit_sdk
 
 import (
-	"github.com/steadybit/discovery-kit/go/discovery_kit_api"
-	"github.com/stretchr/testify/assert"
 	"sync"
 	"testing"
+
+	"github.com/steadybit/discovery-kit/go/discovery_kit_api"
+	"github.com/stretchr/testify/assert"
 )
 
-func Test_withGroupAttribute_copies_map(t *testing.T) {
+func Test_normalizeTargets_copies_map_when_group_set(t *testing.T) {
 	src := map[string][]string{"k": {"v"}}
 	targets := []discovery_kit_api.Target{{Id: "a", Attributes: src}}
 
@@ -18,14 +19,18 @@ func Test_withGroupAttribute_copies_map(t *testing.T) {
 
 	assert.Equal(t, []string{"prod-eu"}, out[0].Attributes[groupAttributeKey])
 	assert.Equal(t, []string{"v"}, out[0].Attributes["k"])
-	// original map is untouched
+	// Source must not be mutated by group injection.
 	_, present := src[groupAttributeKey]
 	assert.False(t, present, "must not mutate the input map")
-	// returned map is a different allocation
-	assert.NotSame(t, &targets[0].Attributes, &out[0].Attributes)
+	// Mutating the returned map must not be visible in the source — proves
+	// they are different map allocations regardless of internal aliasing of
+	// individual slice pointers.
+	out[0].Attributes["sentinel"] = []string{"x"}
+	_, leaked := src["sentinel"]
+	assert.False(t, leaked, "returned map must be a different allocation than the source")
 }
 
-func Test_normalizeEnrichmentData_copies_map(t *testing.T) {
+func Test_normalizeEnrichmentData_copies_map_when_group_set(t *testing.T) {
 	src := map[string][]string{"k": {"v"}}
 	data := []discovery_kit_api.EnrichmentData{{Id: "a", Attributes: src}}
 
@@ -34,17 +39,22 @@ func Test_normalizeEnrichmentData_copies_map(t *testing.T) {
 	assert.Equal(t, []string{"prod-eu"}, out[0].Attributes[groupAttributeKey])
 	_, present := src[groupAttributeKey]
 	assert.False(t, present, "must not mutate the input map")
+	out[0].Attributes["sentinel"] = []string{"x"}
+	_, leaked := src["sentinel"]
+	assert.False(t, leaked, "returned map must be a different allocation than the source")
 }
 
-// Test_withGroupAttribute_is_concurrent_safe locks in the fix for the
-// "concurrent map iteration and map write" panic. Many goroutines call
-// withGroupAttribute on a shared source slice while other goroutines iterate
-// the returned maps — the source maps must never be written to, so iteration
-// against them stays race-free even with the race detector enabled.
-func Test_withGroupAttribute_is_concurrent_safe(t *testing.T) {
+// Test_normalizeTargets_is_concurrent_safe locks in the fix for the
+// "concurrent map iteration and map write" panic plus the multi-valued sort
+// path. Many goroutines call normalizeTargets on a shared source slice that
+// contains both single- and multi-valued attributes (the latter intentionally
+// unsorted so the sort branch is exercised), while other goroutines iterate
+// the source as if encoding it for a JSON response — the source maps must
+// never be written to, so the loop stays race-free even with -race.
+func Test_normalizeTargets_is_concurrent_safe(t *testing.T) {
 	shared := []discovery_kit_api.Target{
-		{Id: "a", Attributes: map[string][]string{"k": {"v"}}},
-		{Id: "b", Attributes: map[string][]string{"k": {"v"}}},
+		{Id: "a", Attributes: map[string][]string{"k": {"v"}, "k8s.hpa": {"bbb", "aaa", "ccc"}}},
+		{Id: "b", Attributes: map[string][]string{"k": {"v"}, "k8s.pdb": {"zzz", "aaa"}}},
 	}
 	var wg sync.WaitGroup
 	for i := 0; i < 8; i++ {
@@ -70,6 +80,9 @@ func Test_withGroupAttribute_is_concurrent_safe(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+	// Source slices must still be in their original order after the concurrent run.
+	assert.Equal(t, []string{"bbb", "aaa", "ccc"}, shared[0].Attributes["k8s.hpa"], "source slice mutated by normalize")
+	assert.Equal(t, []string{"zzz", "aaa"}, shared[1].Attributes["k8s.pdb"], "source slice mutated by normalize")
 }
 
 func Test_normalizeAttributes_handles_nil_source(t *testing.T) {
@@ -92,6 +105,48 @@ func Test_normalizeAttributes_sorts_multivalued(t *testing.T) {
 	assert.Equal(t, []string{"only"}, out["single"], "single-valued slice untouched")
 	assert.Equal(t, []string{"aaa", "bbb", "ccc"}, out["k8s.hpa"], "multi-valued slice sorted")
 	assert.Equal(t, []string{"aaa", "zzz"}, out["k8s.pdb"], "multi-valued slice sorted")
-	// Source must not be mutated.
+	// Both source slices must be untouched (catches an in-place-sort regression
+	// even when one attribute happens to be 2 elements — the case most likely
+	// to be "optimised" into a swap-in-place).
+	assert.Equal(t, []string{"bbb", "aaa", "ccc"}, src["k8s.hpa"], "k8s.hpa source slice must not be mutated")
+	assert.Equal(t, []string{"zzz", "aaa"}, src["k8s.pdb"], "k8s.pdb source slice must not be mutated")
+}
+
+// Test_normalizeAttributes_sorts_multivalued_with_group covers the most
+// production-relevant combination: STEADYBIT_EXTENSION_DISCOVERY_GROUP is set
+// AND the extension reports multi-valued attributes. A future change that
+// only sorts when group=="" (e.g. gated on extra==0) would pass every other
+// test in this file and ship the original platform-DB churn bug to every
+// customer running with a group.
+func Test_normalizeAttributes_sorts_multivalued_with_group(t *testing.T) {
+	src := map[string][]string{
+		"k8s.hpa": {"bbb", "aaa", "ccc"},
+	}
+	out := normalizeAttributes(src, "prod-eu")
+
+	assert.Equal(t, []string{"prod-eu"}, out[groupAttributeKey], "group attribute set")
+	assert.Equal(t, []string{"aaa", "bbb", "ccc"}, out["k8s.hpa"], "multi-valued sorted even when group is set")
 	assert.Equal(t, []string{"bbb", "aaa", "ccc"}, src["k8s.hpa"], "source slice must not be mutated")
+}
+
+// Test_normalizeTargets_fast_path_no_copy_when_already_sorted verifies that
+// targets whose multi-valued attributes are already sorted and that have no
+// group configured are returned without a fresh allocation. Avoids a
+// per-cycle map-copy regression on large-fan-out discoveries.
+func Test_normalizeTargets_fast_path_no_copy_when_already_sorted(t *testing.T) {
+	original := map[string][]string{
+		"single":  {"only"},
+		"k8s.hpa": {"aaa", "bbb", "ccc"}, // already sorted
+	}
+	targets := []discovery_kit_api.Target{{Id: "a", Attributes: original}}
+
+	out := normalizeTargets(targets, "")
+
+	// Same backing slice — no copy was made.
+	assert.Same(t, &targets[0], &out[0], "fast path should return the original slice")
+	// And the map header itself must alias the source, so a write to the returned
+	// map is visible in the source (this is the no-copy contract).
+	out[0].Attributes["touch"] = []string{"x"}
+	_, present := original["touch"]
+	assert.True(t, present, "fast path returns the original map; write is visible in source")
 }


### PR DESCRIPTION
## Summary

Fix for the root cause of the extension-kubernetes platform-DB churn incident: extensions that build multi-valued attribute slices from a Go map or a Kubernetes client-go lister (both iterate in randomized order) made every multi-X target look \"changed\" on every discovery cycle. The platform's target-diff detector compares slices by position, so it wrote to its target store every cycle for unchanged data.

This change normalizes multi-valued attribute slices in the SDK HTTP adapter — every Go-based extension is fixed by default on its next discovery-kit bump.

## What changes

- \`discovery_http_adapter.go\` — \`handleDiscover\` now runs \`normalizeTargets\` / \`normalizeEnrichmentData\` unconditionally (previously only when a group attribute was set).
- New \`normalizeAttributes(src, group)\` consolidates what was \`copyAttributesWithGroup\`: copies the map for concurrent-safety, sorts multi-valued slices, optionally adds the steadybit.group attribute.
- Single-valued slices keep their underlying pointer (no extra alloc).
- Source maps are never mutated, preserving the concurrent-safety property already in place for the group-attribute pass.

## Test plan

- [x] \`go test ./discovery_kit_sdk/\` green, including \`Test_normalizeAttributes_sorts_multivalued\` which locks in the sort behaviour and asserts the source slice is not mutated.
- [x] Existing concurrent-safety test (\`Test_withGroupAttribute_is_concurrent_safe\`, renamed call sites to \`normalizeTargets\`) still passes — 8 goroutines × 500 iterations, no race.

## Note for extensions using parallel multi-valued attributes

If an extension uses parallel multi-valued attributes — i.e. the i-th element of one attribute pairs by index with the i-th of another (e.g. \`k8s.hpa.name=[a,b]\` paired with \`k8s.hpa.min-replicas=[1,5]\` meaning a→1, b→5) — pre-sort the source slice once and rebuild all parallel attribute slices from it, so the per-attribute sort in this PR keeps the pairing aligned. Alternative: encode paired values into one self-contained string per entry (e.g. \`k8s.hpa.spec=[\"a:min=1,max=5\",\"b:min=2,max=10\"]\`). The doc comment on \`normalizeTargets\` calls this out.

## Related

- extension-kubernetes \`extcommon/hpa_pdb_rollup.go\` already pre-sorts its source slices (the immediate fix that landed for the incident), so it stays correct after this lands.