### PR TITLE
fix: surface a panicking discovery as an error, not an empty success

### DIFF
--- a/go/discovery_kit_sdk/CHANGELOG.md
+++ b/go/discovery_kit_sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: a panicking discovery no longer publishes a successful empty result — the recovered panic is now surfaced as an error, so the cache records a failed discovery (and keeps returning an error) instead of an empty target/enrichment set with an advanced ETag
+
 ## 1.3.5
 
 - fix: restore universal application of the discovery group attribute. v1.3.4 moved injection into the cache supplier chain, which skipped discoveries registered without `NewCachedTargetDiscovery` / `NewCachedEnrichmentDataDiscovery` (and any path going through `WithUpdate`). Injection now happens again in the HTTP discovery adapter, but each request builds a fresh copy of every target's attributes before adding `steadybit.group`. The discovery's underlying maps are never mutated, so this is safe under any level of concurrency and works for cached, non-cached, and incrementally-updated discoveries alike.

--- a/go/discovery_kit_sdk/caching_discovery.go
+++ b/go/discovery_kit_sdk/caching_discovery.go
@@ -5,6 +5,7 @@ package discovery_kit_sdk
 import (
 	"context"
 	"errors"
+	"fmt"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -91,6 +92,10 @@ func recoverable[T any](fn discoverFn[T]) discoverFn[T] {
 		defer func() {
 			if err := recover(); err != nil {
 				log.Error().Msgf("discovery panic: %v\n %s", err, string(debug.Stack()))
+				// Surface the panic as an error so the cache records a failed discovery
+				// instead of a successful empty result (which would publish an empty
+				// target/enrichment set and advance the ETag as if it were legitimate).
+				e = fmt.Errorf("discovery panicked: %v", err)
 			}
 		}()
 		return fn(ctx)

--- a/go/discovery_kit_sdk/caching_discovery_target_test.go
+++ b/go/discovery_kit_sdk/caching_discovery_target_test.go
@@ -15,6 +15,17 @@ import (
 	"time"
 )
 
+func Test_recoverable_turns_panic_into_error(t *testing.T) {
+	fn := recoverable[discovery_kit_api.Target](func(context.Context) ([]discovery_kit_api.Target, error) {
+		panic("boom")
+	})
+	data, err := fn(context.Background())
+	assert.Nil(t, data)
+	// Must be an error, not a (nil, nil) "successful empty discovery" that would publish
+	// an empty target set and advance the ETag.
+	assert.Error(t, err)
+}
+
 func Test_target_caching(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Problem

`recoverable` (which wraps every cached discovery's supplier — `caching_discovery.go:57,76`) recovered a discovery panic but left its **named returns at their zero values**, so it returned `(nil, nil)`:

```go
defer func() {
    if err := recover(); err != nil {
        log.Error()...   // logged, but d/e stay nil
    }
}()
return fn(ctx)
```

`Update` then stored that as a **successful discovery of zero targets** — advancing `lastModified`/ETag — so clients received an empty target/enrichment set as if legitimate. A panic in any discovery implementation (across ~33 extensions) silently **wiped that discovery's inventory** with no error surfaced.

## Fix

Set the named error in the recover:

```go
e = fmt.Errorf("discovery panicked: %v", err)
```

Now the cache records a **failed** discovery (`Get` returns the error, as it already does for any other discovery error) instead of a false empty success, so the stale-but-valid state isn't replaced by an empty set presented as current. Adds a regression test (`recoverable` on a panicking fn returns a non-nil error).

## Scope

This is the top (HIGH) discovery-kit audit finding. Lower-severity items noted in the audit remain as possible follow-ups: the `Get()` shared-slice contract (safe today via the group-attribute copy), `internStrings` handle over-allocation, `WithRefreshTimeout` supplier-goroutine leak, and the unsynchronized package registries (safe under the init-then-serve lifecycle).

## Verification

`go build ./...`, `go vet ./...`, `go test -race ./...` pass (module `go/discovery_kit_sdk`); the existing recover/caching tests still pass.
