### PR TITLE
feat(discovery_kit_sdk): bump index revision on register/clear

### DIFF
--- a/go/discovery_kit_sdk/discovery_kit_sdk.go
+++ b/go/discovery_kit_sdk/discovery_kit_sdk.go
@@ -69,6 +69,8 @@ func Register(o any) {
 	if !matched {
 		panic(fmt.Sprintf("unknown discovery type: %T", o))
 	}
+
+	exthttp.BumpRevision()
 }
 
 func registerDiscovery(o any) bool {
@@ -214,4 +216,5 @@ func ClearRegisteredDiscoveries() {
 	registeredTargetDescriber = make(map[string]TargetDescriber)
 	registeredAttributeDescriber = make([]AttributeDescriber, 0)
 	registeredEnrichmentRulesContributions = make(map[string]discovery_kit_api.TargetEnrichmentRule)
+	exthttp.BumpRevision()
 }

--- a/go/discovery_kit_sdk/go.mod
+++ b/go/discovery_kit_sdk/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/steadybit/discovery-kit/go/discovery_kit_api v1.7.1
 	github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1
-	github.com/steadybit/extension-kit v1.10.8
+	github.com/steadybit/extension-kit v1.11.0
 	github.com/stretchr/testify v1.11.1
 	github.com/zmwangx/debounce v1.0.0
 )
@@ -22,7 +22,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
+	github.com/klauspost/compress v1.19.0 // indirect
 	github.com/mailru/easyjson v0.9.1 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -36,7 +36,7 @@ require (
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/woodsbury/decimal128 v1.4.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go/discovery_kit_sdk/go.sum
+++ b/go/discovery_kit_sdk/go.sum
@@ -30,8 +30,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
-github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
-github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.19.0 h1:sXLILfc9jV2QYWkzFOPWStmcUVH2RHEB1JCdY2oVvCQ=
+github.com/klauspost/compress v1.19.0/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -73,8 +73,8 @@ github.com/steadybit/discovery-kit/go/discovery_kit_api v1.7.1 h1:CBMPzLfAF0huCO
 github.com/steadybit/discovery-kit/go/discovery_kit_api v1.7.1/go.mod h1:1Lq/Y33uTb6ezFg7kYy1hJjhpCfLl//qD0p4RqLAMZw=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1 h1:CabRtfE70gt/4H/TgL/TRm54OkxWKbmPhTX2qEhzKZ4=
 github.com/steadybit/discovery-kit/go/discovery_kit_test v1.2.1/go.mod h1:PPJh5gSdVRKG/0qJCGJK5XnGxXat/v6UT8/2ilIbbX8=
-github.com/steadybit/extension-kit v1.10.8 h1:Xr6YmlbTLpIGsLCkVoGF3o4SPvRLl7X3AgpcKRKiQfA=
-github.com/steadybit/extension-kit v1.10.8/go.mod h1:n1PMz8AwjGvl/M/CWSVjoHCE8qM74Tx+nfC4iiuhEPA=
+github.com/steadybit/extension-kit v1.11.0 h1:sliZpOlZKp0XuPKoH3pNyKzI0Tt3iYDCfwaoga5jriw=
+github.com/steadybit/extension-kit v1.11.0/go.mod h1:Bm3pbDipaVc64zpxfOEL9Shpr5CNd4By2x4/jSSr0bA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
 github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=
@@ -90,8 +90,8 @@ github.com/zmwangx/debounce v1.0.0/go.mod h1:U+/QHt+bSMdUh8XKOb6U+MQV5Ew4eS8M3ua
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
-golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=

--- a/go/discovery_kit_sdk/revision_test.go
+++ b/go/discovery_kit_sdk/revision_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+
+package discovery_kit_sdk
+
+import (
+	"testing"
+
+	"github.com/steadybit/extension-kit/exthttp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisterBumpsRevision(t *testing.T) {
+	ClearRegisteredDiscoveries()
+	t.Cleanup(ClearRegisteredDiscoveries)
+
+	before := exthttp.Revision()
+	Register(newMockTargetDiscovery())
+	assert.NotEqual(t, before, exthttp.Revision(), "Register must bump the index revision")
+}
+
+func TestClearRegisteredDiscoveriesBumpsRevision(t *testing.T) {
+	before := exthttp.Revision()
+	ClearRegisteredDiscoveries()
+	assert.NotEqual(t, before, exthttp.Revision(), "ClearRegisteredDiscoveries must bump the index revision")
+}

--- a/go/discovery_kit_sdk/revision_test.go
+++ b/go/discovery_kit_sdk/revision_test.go
@@ -5,7 +5,9 @@ package discovery_kit_sdk
 
 import (
 	"testing"
+	"time"
 
+	"github.com/steadybit/discovery-kit/go/discovery_kit_api"
 	"github.com/steadybit/extension-kit/exthttp"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,8 +16,19 @@ func TestRegisterBumpsRevision(t *testing.T) {
 	ClearRegisteredDiscoveries()
 	t.Cleanup(ClearRegisteredDiscoveries)
 
+	// Use a discovery id unique to this test: registration installs routes on the process-global
+	// http.DefaultServeMux, and ClearRegisteredDiscoveries does not remove them, so reusing an id
+	// another test already registered would panic on a duplicate route.
+	discovery := &MockTargetDiscovery{MockDiscovery{Now: time.Now}}
+	discovery.On("Describe").Return(discovery_kit_api.DiscoveryDescription{Id: "revision-test"})
+	discovery.On("DescribeTarget").Return(discovery_kit_api.TargetDescription{
+		Id:    "revision-test",
+		Label: discovery_kit_api.PluralLabel{One: "Revision Test", Other: "Revision Tests"},
+	})
+	discovery.On("DescribeAttributes").Return([]discovery_kit_api.AttributeDescription{})
+
 	before := exthttp.Revision()
-	Register(newMockTargetDiscovery())
+	Register(discovery)
 	assert.NotEqual(t, before, exthttp.Revision(), "Register must bump the index revision")
 }
 


### PR DESCRIPTION
## What

`Register` and `ClearRegisteredDiscoveries` now call `exthttp.BumpRevision()` so the extension index ETag reflects the registered discoveries/target describers/attribute describers/enrichment rules.

The runtime `Discover` (discovered-targets) endpoint keeps its own existing `IfNoneMatchHandler(LastModified())` ETag — that's a different endpoint and is intentionally untouched.

## Why

Part of centralizing index-response caching in the SDKs (see steadybit/extension-kit#158). The index ETag becomes registration-scoped instead of frozen at process start.

## Depends on

steadybit/extension-kit#158 — `exthttp.BumpRevision` is introduced there. **CI on this PR is red until extension-kit is tagged**; I'll bump `go.mod`/`go.sum` to the new tag as a follow-up commit.